### PR TITLE
fuse-ops.c: populate st_blocks

### DIFF
--- a/src/fuse-ops.c
+++ b/src/fuse-ops.c
@@ -362,6 +362,7 @@ seadrive_fuse_getattr(const char *path, struct stat *stbuf)
         stbuf->st_mode = S_IFDIR | 0755;
         stbuf->st_nlink = 2;
         stbuf->st_size = 4096;
+        stbuf->st_blocks = 8;
         stbuf->st_uid = uid;
         stbuf->st_gid = gid;
         if (comps.multi_account && comps.account_info)
@@ -372,6 +373,7 @@ seadrive_fuse_getattr(const char *path, struct stat *stbuf)
         stbuf->st_mode = S_IFDIR | 0755;
         stbuf->st_nlink = 2;
         stbuf->st_size = 4096;
+        stbuf->st_blocks = 8;
         stbuf->st_uid = uid;
         stbuf->st_gid = gid;
         stbuf->st_mtime = get_category_dir_mtime (comps.account_info->server, comps.account_info->username, comps.repo_type);
@@ -380,6 +382,7 @@ seadrive_fuse_getattr(const char *path, struct stat *stbuf)
         stbuf->st_mode = S_IFDIR | 0755;
         stbuf->st_nlink = 2;
         stbuf->st_size = 4096;
+        stbuf->st_blocks = 8;
         stbuf->st_mtime = comps.repo_info->mtime;
         stbuf->st_uid = uid;
         stbuf->st_gid = gid;
@@ -404,12 +407,14 @@ seadrive_fuse_getattr(const char *path, struct stat *stbuf)
                                                                        comps.repo_path));
         if (S_ISDIR(st.mode)) {
             stbuf->st_size = 4096;
+            stbuf->st_blocks = 8;
             if (is_writable)
                 stbuf->st_mode = S_IFDIR | 0755;
             else
                 stbuf->st_mode = S_IFDIR | 0555;
         } else {
             stbuf->st_size = st.size;
+            stbuf->st_blocks = (st.size + 511) / 512;
             if (is_writable)
                 stbuf->st_mode = S_IFREG | 0644;
             else


### PR DESCRIPTION
Correctly populates `st_blocks` field in `seadrive_fuse_getattr`. For directories that's 8 blocks, for files it's `ceil ( size / 512 )` blocks.

Currently it is unpopulated, which technically communicates to a caller that the file is a "hole" and has no data. This might cause the underlying data to not actually be read when copying:

```bash
# Before
$ ls -sl SeaDrive/example.bin
0 -rw-r--r-- 1 bob users 10842112 Jun  4 21:20 example.bin

# After
$ ls -sl SeaDrive/example.bin
10588 -rw-r--r-- 1 bob users 10842112 Jun  4 21:20 example.bin
```